### PR TITLE
Fix code scanning alert no. 7: Incomplete regular expression for hostnames

### DIFF
--- a/test/spec/services/osm.js
+++ b/test/spec/services/osm.js
@@ -778,8 +778,8 @@ describe('iD.serviceOsm', function () {
             </api>
             <policy>
                 <imagery>
-                    <blacklist regex="\.foo\.com"/>
-                    <blacklist regex="\.bar\.org"/>
+                    <blacklist regex="\\.foo\\.com"/>
+                    <blacklist regex="\\.bar\\.org"/>
                 </imagery>
             </policy>
         </osm>`;
@@ -813,7 +813,7 @@ describe('iD.serviceOsm', function () {
 
                 connection.status(function() {
                     var blocklists = connection.imageryBlocklists();
-                    expect(blocklists).to.deep.equal([new RegExp('\.foo\.com'), new RegExp('\.bar\.org')]);
+                    expect(blocklists).to.deep.equal([new RegExp('\\.foo\\.com'), new RegExp('\\.bar\\.org')]);
                     done();
                 });
             });


### PR DESCRIPTION
Fixes [https://github.com/universalbit-dev/iD/security/code-scanning/7](https://github.com/universalbit-dev/iD/security/code-scanning/7)

To fix the problem, we need to escape the `.` characters in the regular expressions to ensure they match literal dots rather than any character. This can be done by adding a backslash (`\`) before each `.` character in the regular expression. 

Specifically, we need to update the regular expressions in the `blacklist` elements within the `capabilitiesXML` string and the corresponding `expect` statement in the test case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
