### PR TITLE
Fix code scanning alert no. 13: Useless regular-expression character escape

### DIFF
--- a/test/spec/ui/fields/wikipedia.js
+++ b/test/spec/ui/fields/wikipedia.js
@@ -27,7 +27,7 @@ describe('iD.uiFieldWikipedia', function() {
             type: 'wikipedia'
         });
         fetchMock.reset();
-        fetchMock.mock(new RegExp('\/w\/api\.php.*action=wbgetentities'), {
+        fetchMock.mock(new RegExp('\/w\/api\\.php.*action=wbgetentities'), {
             body: '{"entities":{"Q216353":{"id":"Q216353"}}}',
             status: 200,
             headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
Fixes [https://github.com/universalbit-dev/iD/security/code-scanning/13](https://github.com/universalbit-dev/iD/security/code-scanning/13)

To fix the problem, we need to ensure that the regular expression correctly matches a literal period character. This can be achieved by using double backslashes (`\\.`) in the string literal, which will be interpreted as a single backslash in the regular expression, thus correctly escaping the period character.

- Change the regular expression string on line 30 to use double backslashes for the period character.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
